### PR TITLE
Changed module provider to handle synchronization in a more relaxed m…

### DIFF
--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/DependentModule.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/DependentModule.kt
@@ -1,5 +1,14 @@
 package com.papsign.ktor.openapigen.modules
 
+import com.papsign.ktor.openapigen.getKType
+import kotlin.reflect.KType
+
 interface DependentModule {
-    val handlers: Collection<OpenAPIModule>
+    val handlers: Collection<Pair<KType, OpenAPIModule>>
+
+    companion object {
+        inline fun <reified T: OpenAPIModule> handler(handler: T): Pair<KType, T> {
+            return getKType<T>() to handler
+        }
+    }
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/AuthProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/AuthProvider.kt
@@ -3,19 +3,21 @@ package com.papsign.ktor.openapigen.modules.providers
 import com.papsign.ktor.openapigen.model.Described
 import com.papsign.ktor.openapigen.model.security.SecuritySchemeModel
 import com.papsign.ktor.openapigen.modules.DependentModule
+import com.papsign.ktor.openapigen.modules.DependentModule.Companion.handler
 import com.papsign.ktor.openapigen.modules.OpenAPIModule
 import com.papsign.ktor.openapigen.modules.handlers.AuthHandler
 import com.papsign.ktor.openapigen.route.path.auth.OpenAPIAuthenticatedRoute
 import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
 import io.ktor.application.ApplicationCall
 import io.ktor.util.pipeline.PipelineContext
+import kotlin.reflect.KType
 
 interface AuthProvider<TAuth>: OpenAPIModule, DependentModule {
     suspend fun getAuth(pipeline: PipelineContext<Unit, ApplicationCall>): TAuth
     fun apply(route: NormalOpenAPIRoute): OpenAPIAuthenticatedRoute<TAuth>
     val security: Iterable<Iterable<Security<*>>>
-    override val handlers: Collection<OpenAPIModule>
-        get() = listOf(AuthHandler)
+    override val handlers: Collection<Pair<KType, OpenAPIModule>>
+        get() = listOf(handler(AuthHandler))
 
     data class  Security<TScope>(val scheme: SecuritySchemeModel<TScope>, val requirements: List<TScope>) where TScope: Enum<TScope>, TScope: Described
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/MethodProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/MethodProvider.kt
@@ -1,12 +1,15 @@
 package com.papsign.ktor.openapigen.modules.providers
 
+import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.modules.DependentModule
+import com.papsign.ktor.openapigen.modules.DependentModule.Companion.handler
 import com.papsign.ktor.openapigen.modules.OpenAPIModule
 import com.papsign.ktor.openapigen.modules.handlers.RouteHandler
 import io.ktor.http.HttpMethod
+import kotlin.reflect.KType
 
 interface MethodProvider : OpenAPIModule, DependentModule {
     val method: HttpMethod
-    override val handlers: Collection<OpenAPIModule>
-        get() = listOf(RouteHandler)
+    override val handlers: Collection<Pair<KType, OpenAPIModule>>
+        get() = listOf(handler(RouteHandler))
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/TagProviderModule.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/TagProviderModule.kt
@@ -1,13 +1,16 @@
 package com.papsign.ktor.openapigen.modules.providers
 
 import com.papsign.ktor.openapigen.APITag
+import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.modules.DependentModule
+import com.papsign.ktor.openapigen.modules.DependentModule.Companion.handler
 import com.papsign.ktor.openapigen.modules.OpenAPIModule
 import com.papsign.ktor.openapigen.modules.RouteOpenAPIModule
 import com.papsign.ktor.openapigen.modules.handlers.TagHandlerModule
+import kotlin.reflect.KType
 
 interface TagProviderModule: RouteOpenAPIModule, DependentModule {
     val tags: Collection<APITag>
-    override val handlers: Collection<OpenAPIModule>
-        get() = listOf(TagHandlerModule)
+    override val handlers: Collection<Pair<KType, OpenAPIModule>>
+        get() = listOf(handler(TagHandlerModule))
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/ThrowInfoProvider.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/modules/providers/ThrowInfoProvider.kt
@@ -2,11 +2,13 @@ package com.papsign.ktor.openapigen.modules.providers
 
 import com.papsign.ktor.openapigen.APIException
 import com.papsign.ktor.openapigen.modules.DependentModule
+import com.papsign.ktor.openapigen.modules.DependentModule.Companion.handler
 import com.papsign.ktor.openapigen.modules.OpenAPIModule
 import com.papsign.ktor.openapigen.modules.handlers.ThrowOperationHandler
+import kotlin.reflect.KType
 
 interface ThrowInfoProvider: OpenAPIModule, DependentModule {
     val exceptions: List<APIException<*, *>>
-    override val handlers: Collection<OpenAPIModule>
-        get() = listOf(ThrowOperationHandler)
+    override val handlers: Collection<Pair<KType, OpenAPIModule>>
+        get() = listOf(handler(ThrowOperationHandler))
 }

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/Functions.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/Functions.kt
@@ -3,6 +3,7 @@ package com.papsign.ktor.openapigen.route
 import com.papsign.ktor.openapigen.APITag
 import com.papsign.ktor.openapigen.annotations.Path
 import com.papsign.ktor.openapigen.content.type.ContentTypeProvider
+import com.papsign.ktor.openapigen.getKType
 import com.papsign.ktor.openapigen.modules.handlers.RequestHandlerModule
 import com.papsign.ktor.openapigen.modules.handlers.ResponseHandlerModule
 import com.papsign.ktor.openapigen.modules.registerModule
@@ -13,7 +14,11 @@ import io.ktor.routing.HttpMethodRouteSelector
 import io.ktor.routing.createRouteFromPath
 import io.ktor.util.pipeline.ContextDsl
 import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance
+import kotlin.reflect.full.createType
 import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 
@@ -141,13 +146,15 @@ internal fun <TParams : Any, TResponse : Any, TRequest : Any, TRoute : OpenAPIRo
             RequestHandlerModule.create(
                 bType,
                 exampleRequest
-            )
+            ),
+            RequestHandlerModule::class.createType(listOf(KTypeProjection(KVariance.INVARIANT, bType)))
         )
         provider.registerModule(
             ResponseHandlerModule.create(
                 rType,
                 exampleResponse
-            )
+            ),
+            ResponseHandlerModule::class.createType(listOf(KTypeProjection(KVariance.INVARIANT, rType)))
         )
         if (path != null) {
             provider.registerModule(PathProviderModule(path.path))

--- a/src/main/kotlin/com/papsign/ktor/openapigen/route/OpenAPIRoute.kt
+++ b/src/main/kotlin/com/papsign/ktor/openapigen/route/OpenAPIRoute.kt
@@ -11,6 +11,7 @@ import com.papsign.ktor.openapigen.modules.ofType
 import com.papsign.ktor.openapigen.modules.openapi.HandlerModule
 import com.papsign.ktor.openapigen.modules.registerModule
 import com.papsign.ktor.openapigen.openAPIGen
+import com.papsign.ktor.openapigen.parameters.handlers.ParameterHandler
 import com.papsign.ktor.openapigen.parameters.util.buildParameterHandler
 import com.papsign.ktor.openapigen.route.response.Responder
 import com.papsign.ktor.openapigen.validation.ValidationHandler
@@ -24,6 +25,9 @@ import io.ktor.routing.application
 import io.ktor.routing.contentType
 import io.ktor.util.pipeline.PipelineContext
 import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance
+import kotlin.reflect.full.createType
 
 abstract class OpenAPIRoute<T : OpenAPIRoute<T>>(val ktorRoute: Route, val provider: CachingModuleProvider) {
     private val log = classLogger()
@@ -37,7 +41,7 @@ abstract class OpenAPIRoute<T : OpenAPIRoute<T>>(val ktorRoute: Route, val provi
         pass: suspend OpenAPIRoute<*>.(pipeline: PipelineContext<Unit, ApplicationCall>, responder: Responder, P, B) -> Unit
     ) {
         val parameterHandler = buildParameterHandler<P>(paramsType)
-        provider.registerModule(parameterHandler)
+        provider.registerModule(parameterHandler, ParameterHandler::class.createType(listOf(KTypeProjection(KVariance.INVARIANT, paramsType))))
 
         val apiGen = ktorRoute.application.openAPIGen
         provider.ofType<HandlerModule>().forEach {


### PR DESCRIPTION
…anner

Changed module provider to fix issue with erased types
Changed Dependent module order, now are loaded before the type module that requires them, if and only if they are not already present
Added type precision in the KType based module registration which erased types
Changed dependent module registration to allow for generic specialized types without erasure by providing KType.